### PR TITLE
Fix incompatibility with Laravel 4.2

### DIFF
--- a/bin/laravel.php
+++ b/bin/laravel.php
@@ -460,7 +460,7 @@ class RouterWrapper extends Router
         $this->process('any', func_get_args());
     }
 
-    public function resource($pattern, $arguments)
+    public function resource($pattern, $arguments, array $opt = array())
     {
         $this->process('resource', func_get_args());
     }


### PR DESCRIPTION
Fixed Declaration of RouterWrapper::resource() incompatible with Illuminate\Routing\Router::resource() for laravel 4.2
